### PR TITLE
Implement Block Packing Optimization for Matrix Multiplication

### DIFF
--- a/include/triton/Dialect/Triton/Transforms/Passes.h
+++ b/include/triton/Dialect/Triton/Transforms/Passes.h
@@ -12,6 +12,7 @@ std::unique_ptr<Pass> createLoopInvariantCodeMotionPass();
 std::unique_ptr<Pass> createReorderBroadcastPass();
 std::unique_ptr<Pass> createRewriteTensorPointerPass();
 std::unique_ptr<Pass> createLoopUnrollPass();
+std::unique_ptr<Pass> createTritonCPUBlockPackingPass();
 
 } // namespace triton
 

--- a/lib/Dialect/Triton/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Triton/Transforms/CMakeLists.txt
@@ -8,6 +8,7 @@ add_triton_library(TritonTransforms
   LoopUnroll.cpp
   ReorderBroadcast.cpp
   RewriteTensorPointer.cpp
+  TritonCPUBlockPacking.cpp
 
   DEPENDS
   TritonTransformsIncGen

--- a/lib/Dialect/Triton/Transforms/TritonCPUBlockPacking.cpp
+++ b/lib/Dialect/Triton/Transforms/TritonCPUBlockPacking.cpp
@@ -1,0 +1,487 @@
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+
+using namespace mlir;
+using namespace triton;
+
+namespace {
+
+// Constant for Cache Tile Size
+constexpr int64_t CACHE_TILE_K = 256;
+
+// Helper to convert memref to triton pointer
+Value memrefToPtr(PatternRewriter &rewriter, Location loc, Value memref) {
+    auto memRefType = mlir::cast<MemRefType>(memref.getType());
+    Type elemType = memRefType.getElementType();
+    
+    Value basePtrIndex = rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(loc, memref);
+    Value basePtrInt = rewriter.create<arith::IndexCastOp>(loc, rewriter.getI64Type(), basePtrIndex);
+    
+    Type ptrType = triton::PointerType::get(elemType, 0);
+    return rewriter.create<triton::IntToPtrOp>(loc, ptrType, basePtrInt);
+}
+
+// Helper to create a tensor of pointers
+Value getPtrTensor(PatternRewriter &rewriter, Location loc, Value basePtr, ArrayRef<int64_t> shape, Value offsetK, int64_t packedWidth, bool isA) {
+    int64_t dim0 = shape[0];
+    int64_t dim1 = shape[1];
+    
+    // Create ranges
+    Value range0 = rewriter.create<triton::MakeRangeOp>(loc, RankedTensorType::get({dim0}, rewriter.getI32Type()), 0, dim0);
+    Value range1 = rewriter.create<triton::MakeRangeOp>(loc, RankedTensorType::get({dim1}, rewriter.getI32Type()), 0, dim1);
+    
+    // Broadcast
+    Value range0Bc = rewriter.create<triton::ExpandDimsOp>(loc, range0, 1);
+    range0Bc = rewriter.create<triton::BroadcastOp>(loc, RankedTensorType::get({dim0, dim1}, rewriter.getI32Type()), range0Bc);
+    
+    Value range1Bc = rewriter.create<triton::ExpandDimsOp>(loc, range1, 0);
+    range1Bc = rewriter.create<triton::BroadcastOp>(loc, RankedTensorType::get({dim0, dim1}, rewriter.getI32Type()), range1Bc);
+    
+    Value cPackedWidth = rewriter.create<arith::ConstantIntOp>(loc, packedWidth, 32);
+    Value splatPackedWidth = rewriter.create<triton::SplatOp>(loc, RankedTensorType::get({dim0, dim1}, rewriter.getI32Type()), cPackedWidth);
+    
+    Value offsetK_i32 = rewriter.create<arith::IndexCastOp>(loc, rewriter.getI32Type(), offsetK);
+    Value splatOffsetK = rewriter.create<triton::SplatOp>(loc, RankedTensorType::get({dim0, dim1}, rewriter.getI32Type()), offsetK_i32);
+    
+    Value linearOffset;
+    if (isA) {
+        // i * packedWidth + j + offsetK
+        Value term0 = rewriter.create<arith::MulIOp>(loc, range0Bc, splatPackedWidth);
+        Value term1 = rewriter.create<arith::AddIOp>(loc, term0, range1Bc);
+        linearOffset = rewriter.create<arith::AddIOp>(loc, term1, splatOffsetK);
+    } else {
+        // (i + offsetK) * packedWidth + j
+        Value iPlusOffset = rewriter.create<arith::AddIOp>(loc, range0Bc, splatOffsetK);
+        Value term0 = rewriter.create<arith::MulIOp>(loc, iPlusOffset, splatPackedWidth);
+        linearOffset = rewriter.create<arith::AddIOp>(loc, term0, range1Bc);
+    }
+    
+    Value splatBase = rewriter.create<triton::SplatOp>(loc, RankedTensorType::get({dim0, dim1}, basePtr.getType()), basePtr);
+    return rewriter.create<triton::AddPtrOp>(loc, splatBase.getType(), splatBase, linearOffset);
+}
+
+// Helper to store a tensor to a memref (pointer)
+void storeTensorToMemRef(PatternRewriter &rewriter, Location loc, Value tensor, Value memref, Value offsetK, bool isA) {
+    auto tensorType = mlir::cast<RankedTensorType>(tensor.getType());
+    auto shape = tensorType.getShape();
+    
+    // Get packed width from memref shape
+    auto memRefType = mlir::cast<MemRefType>(memref.getType());
+    int64_t packedWidth = memRefType.getShape()[1];
+    
+    Value basePtr = memrefToPtr(rewriter, loc, memref);
+    Value ptrs = getPtrTensor(rewriter, loc, basePtr, shape, offsetK, packedWidth, isA);
+    
+    rewriter.create<triton::StoreOp>(loc, ptrs, tensor, triton::CacheModifier::NONE, triton::EvictionPolicy::NORMAL);
+}
+
+// Helper to load a tensor from a memref (pointer)
+Value loadTensorFromMemRef(PatternRewriter &rewriter, Location loc, Value memref, Value offsetK, RankedTensorType tensorType, bool isA) {
+    auto shape = tensorType.getShape();
+    
+    // Get packed width from memref shape
+    auto memRefType = mlir::cast<MemRefType>(memref.getType());
+    int64_t packedWidth = memRefType.getShape()[1];
+    
+    Value basePtr = memrefToPtr(rewriter, loc, memref);
+    Value ptrs = getPtrTensor(rewriter, loc, basePtr, shape, offsetK, packedWidth, isA);
+    
+    return rewriter.create<triton::LoadOp>(loc, ptrs, triton::CacheModifier::NONE, triton::EvictionPolicy::NORMAL, false);
+}
+
+struct BlockPackingPattern : public OpRewritePattern<scf::ForOp> {
+  using OpRewritePattern<scf::ForOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(scf::ForOp forOp, PatternRewriter &rewriter) const override {
+    auto dotOps = forOp.getOps<triton::DotOp>();
+    if (dotOps.empty()) return failure();
+    triton::DotOp dotOp = *dotOps.begin();
+
+    Value lb = forOp.getLowerBound();
+    Value ub = forOp.getUpperBound();
+    Value step = forOp.getStep();
+
+    if (!step) return failure();
+    
+    int64_t blockK = 0;
+    Operation *defOp = step.getDefiningOp();
+    if (auto constOp = dyn_cast_or_null<arith::ConstantIndexOp>(defOp)) {
+        blockK = constOp.value();
+    } else if (auto constOp = dyn_cast_or_null<arith::ConstantIntOp>(defOp)) {
+        blockK = constOp.value();
+    } else if (auto constOp = dyn_cast_or_null<arith::ConstantOp>(defOp)) {
+        if (auto intAttr = dyn_cast<IntegerAttr>(constOp.getValue())) {
+            blockK = intAttr.getInt();
+        } else {
+            return failure();
+        }
+    } else {
+        return failure();
+    }
+    
+
+
+    if (blockK >= CACHE_TILE_K) return failure();
+    if (blockK <= 0) return failure();
+
+    // Check if loop range is small enough to skip tiling
+    // This prevents infinite recursion when the pass runs on the generated inner loop
+    int64_t lbVal = -1, ubVal = -1;
+    if (auto constLb = dyn_cast_or_null<arith::ConstantIndexOp>(lb.getDefiningOp())) lbVal = constLb.value();
+    else if (auto constLb = dyn_cast_or_null<arith::ConstantIntOp>(lb.getDefiningOp())) lbVal = constLb.value();
+    
+    if (auto constUb = dyn_cast_or_null<arith::ConstantIndexOp>(ub.getDefiningOp())) ubVal = constUb.value();
+    else if (auto constUb = dyn_cast_or_null<arith::ConstantIntOp>(ub.getDefiningOp())) ubVal = constUb.value();
+    
+    if (lbVal != -1 && ubVal != -1) {
+        int64_t diff = ubVal - lbVal;
+        if (diff < 0) diff = -diff;
+        if (diff <= CACHE_TILE_K) return failure();
+    }
+
+    // Identify A and B
+    Value a = dotOp.getA();
+    Value b = dotOp.getB();
+    auto loadA = a.getDefiningOp<triton::LoadOp>();
+    auto loadB = b.getDefiningOp<triton::LoadOp>();
+    
+    if (!loadA || !loadB) return failure();
+
+    // Create Outer Loop
+    Type loopType = step.getType();
+    Value cCacheTileK;
+    if (loopType.isIndex()) {
+        cCacheTileK = rewriter.create<arith::ConstantIndexOp>(forOp.getLoc(), CACHE_TILE_K);
+    } else {
+        cCacheTileK = rewriter.create<arith::ConstantIntOp>(forOp.getLoc(), CACHE_TILE_K, loopType);
+    }
+
+    SmallVector<Value> iterArgs = forOp.getInitArgs();
+    auto outerLoop = rewriter.create<scf::ForOp>(
+        forOp.getLoc(), lb, ub, 
+        cCacheTileK,
+        iterArgs);
+    
+    rewriter.setInsertionPointToStart(outerLoop.getBody());
+    Value kOuter = outerLoop.getInductionVar();
+
+    auto tensorTypeA = mlir::cast<RankedTensorType>(a.getType());
+    auto tensorTypeB = mlir::cast<RankedTensorType>(b.getType());
+    
+    // Allocate Scratchpads
+    SmallVector<int64_t> packedShapeA = {tensorTypeA.getShape()[0], CACHE_TILE_K};
+    auto memRefTypeA = MemRefType::get(packedShapeA, tensorTypeA.getElementType());
+    Value packedA = rewriter.create<memref::AllocaOp>(forOp.getLoc(), memRefTypeA);
+    
+    SmallVector<int64_t> packedShapeB = {CACHE_TILE_K, tensorTypeB.getShape()[1]};
+    auto memRefTypeB = MemRefType::get(packedShapeB, tensorTypeB.getElementType());
+    Value packedB = rewriter.create<memref::AllocaOp>(forOp.getLoc(), memRefTypeB);
+
+    // Packing Loop
+    Value c0;
+    if (loopType.isIndex()) {
+        c0 = rewriter.create<arith::ConstantIndexOp>(forOp.getLoc(), 0);
+    } else {
+        c0 = rewriter.create<arith::ConstantIntOp>(forOp.getLoc(), 0, loopType);
+    }
+    // cCacheTileK is already created with correct type
+    Value cBlockK;
+    if (loopType.isIndex()) {
+        cBlockK = rewriter.create<arith::ConstantIndexOp>(forOp.getLoc(), blockK);
+    } else {
+        cBlockK = rewriter.create<arith::ConstantIntOp>(forOp.getLoc(), blockK, loopType);
+    }
+    
+    auto packingLoop = rewriter.create<scf::ForOp>(
+        forOp.getLoc(), c0, cCacheTileK, cBlockK, outerLoop.getRegionIterArgs());
+        
+    rewriter.setInsertionPointToStart(packingLoop.getBody());
+    Value kInnerPack = packingLoop.getInductionVar();
+    Value globalK = rewriter.create<arith::AddIOp>(forOp.getLoc(), kOuter, kInnerPack);
+    
+    // Find Accumulator Index
+    auto regionIterArgs = forOp.getRegionIterArgs();
+    int accIdx = -1;
+    for (int i = 0; i < regionIterArgs.size(); ++i) {
+        if (regionIterArgs[i] == dotOp.getOperand(2)) {
+            accIdx = i;
+            break;
+        }
+    }
+    if (accIdx == -1) return failure();
+
+    // Clone Loads
+    IRMapping mapping;
+    mapping.map(forOp.getInductionVar(), globalK);
+    for (int i = 0; i < regionIterArgs.size(); ++i) {
+        mapping.map(regionIterArgs[i], packingLoop.getRegionIterArgs()[i]);
+    }
+    
+    std::function<Value(Value)> cloneRecursive = [&](Value val) -> Value {
+        if (mapping.contains(val)) return mapping.lookup(val);
+        Operation* defOp = val.getDefiningOp();
+        if (!defOp || defOp->getBlock() != forOp.getBody()) return val;
+        
+        IRMapping localMap;
+        for (Value op : defOp->getOperands()) {
+            localMap.map(op, cloneRecursive(op));
+        }
+        Operation* clonedOp = rewriter.clone(*defOp, localMap);
+        for (unsigned i = 0; i < defOp->getNumResults(); ++i) {
+            mapping.map(defOp->getResult(i), clonedOp->getResult(i));
+        }
+        for (unsigned i = 0; i < defOp->getNumResults(); ++i) {
+            if (defOp->getResult(i) == val) return clonedOp->getResult(i);
+        }
+        return Value();
+    };
+
+    // Clone dependencies for LoadA
+    for (Value op : loadA->getOperands()) {
+        cloneRecursive(op);
+    }
+    Operation* newLoadA = rewriter.clone(*loadA, mapping);
+    
+    // Clone dependencies for LoadB
+    for (Value op : loadB->getOperands()) {
+        cloneRecursive(op);
+    }
+    Operation* newLoadB = rewriter.clone(*loadB, mapping);
+    
+    // Store to Packed
+    storeTensorToMemRef(rewriter, forOp.getLoc(), newLoadA->getResult(0), packedA, kInnerPack, true);
+    storeTensorToMemRef(rewriter, forOp.getLoc(), newLoadB->getResult(0), packedB, kInnerPack, false);
+    
+    // Yield updated args
+    auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+    SmallVector<Value> packingYieldValues;
+    for (int i = 0; i < iterArgs.size(); ++i) {
+        if (i == accIdx) {
+            packingYieldValues.push_back(packingLoop.getRegionIterArgs()[i]);
+        } else {
+            Value nextVal = cloneRecursive(yieldOp.getOperand(i));
+            packingYieldValues.push_back(nextVal);
+        }
+    }
+    
+    {
+        Block *body = packingLoop.getBody();
+        // llvm::errs() << "Packing Loop Body:\n";
+        // for (auto &op : *body) llvm::errs() << "  " << op.getName() << "\n";
+        
+        if (!body->empty() && body->back().hasTrait<OpTrait::IsTerminator>()) {
+            rewriter.replaceOpWithNewOp<scf::YieldOp>(&body->back(), packingYieldValues);
+        } else {
+            rewriter.create<scf::YieldOp>(forOp.getLoc(), packingYieldValues);
+        }
+    }
+    
+    rewriter.setInsertionPointAfter(packingLoop);
+
+    // Inner Compute Loop
+    auto innerLoop = rewriter.create<scf::ForOp>(
+        forOp.getLoc(), c0, cCacheTileK, cBlockK, packingLoop.getResults());
+    
+    rewriter.setInsertionPointToStart(innerLoop.getBody());
+    Value kInner = innerLoop.getInductionVar();
+    Value accInner = innerLoop.getRegionIterArgs()[accIdx];
+    
+    // Load from Packed
+    Value aFast = loadTensorFromMemRef(rewriter, forOp.getLoc(), packedA, kInner, tensorTypeA, true);
+    Value bFast = loadTensorFromMemRef(rewriter, forOp.getLoc(), packedB, kInner, tensorTypeB, false);
+    
+    // Dot
+    SmallVector<Value> newDotOperands;
+    newDotOperands.push_back(aFast);
+    newDotOperands.push_back(bFast);
+    newDotOperands.push_back(accInner); // C
+    
+    auto newDot = rewriter.create<triton::DotOp>(forOp.getLoc(), dotOp.getType(), newDotOperands, dotOp->getAttrs());
+    
+    SmallVector<Value> innerYieldValues;
+    for (int i = 0; i < iterArgs.size(); ++i) {
+        if (i == accIdx) {
+            innerYieldValues.push_back(newDot.getResult());
+        } else {
+            innerYieldValues.push_back(innerLoop.getRegionIterArgs()[i]);
+        }
+    }
+    
+    {
+        Block *body = innerLoop.getBody();
+        // llvm::errs() << "Inner Loop Body:\n";
+        // for (auto &op : *body) llvm::errs() << "  " << op.getName() << "\n";
+
+        if (!body->empty() && body->back().hasTrait<OpTrait::IsTerminator>()) {
+            rewriter.replaceOpWithNewOp<scf::YieldOp>(&body->back(), innerYieldValues);
+        } else {
+            rewriter.create<scf::YieldOp>(forOp.getLoc(), innerYieldValues);
+        }
+    }
+    
+    rewriter.setInsertionPointAfter(innerLoop);
+    
+    {
+        Block *body = outerLoop.getBody();
+        // llvm::errs() << "Outer Loop Body:\n";
+        // for (auto &op : *body) llvm::errs() << "  " << op.getName() << "\n";
+
+        if (!body->empty() && body->back().hasTrait<OpTrait::IsTerminator>()) {
+            rewriter.replaceOpWithNewOp<scf::YieldOp>(&body->back(), innerLoop.getResults());
+        } else {
+            rewriter.create<scf::YieldOp>(forOp.getLoc(), innerLoop.getResults());
+        }
+    }
+    
+    rewriter.replaceOp(forOp, outerLoop.getResults());
+    
+    return success();
+  }
+};
+/*
+    auto tensorTypeA = mlir::cast<RankedTensorType>(a.getType());
+    auto tensorTypeB = mlir::cast<RankedTensorType>(b.getType());
+    
+    // Allocate Scratchpads
+    SmallVector<int64_t> packedShapeA = {tensorTypeA.getShape()[0], CACHE_TILE_K};
+    auto memRefTypeA = MemRefType::get(packedShapeA, tensorTypeA.getElementType());
+    Value packedA = rewriter.create<memref::AllocaOp>(forOp.getLoc(), memRefTypeA);
+    
+    SmallVector<int64_t> packedShapeB = {CACHE_TILE_K, tensorTypeB.getShape()[1]};
+    auto memRefTypeB = MemRefType::get(packedShapeB, tensorTypeB.getElementType());
+    Value packedB = rewriter.create<memref::AllocaOp>(forOp.getLoc(), memRefTypeB);
+
+    // Packing Loop
+    Value c0;
+    if (loopType.isIndex()) {
+        c0 = rewriter.create<arith::ConstantIndexOp>(forOp.getLoc(), 0);
+    } else {
+        c0 = rewriter.create<arith::ConstantIntOp>(forOp.getLoc(), 0, loopType);
+    }
+    // cCacheTileK is already created with correct type
+    Value cBlockK;
+    if (loopType.isIndex()) {
+        cBlockK = rewriter.create<arith::ConstantIndexOp>(forOp.getLoc(), blockK);
+    } else {
+        cBlockK = rewriter.create<arith::ConstantIntOp>(forOp.getLoc(), blockK, loopType);
+    }
+    
+    auto packingLoop = rewriter.create<scf::ForOp>(
+        forOp.getLoc(), c0, cCacheTileK, cBlockK);
+        
+    rewriter.setInsertionPointToStart(packingLoop.getBody());
+    Value kInnerPack = packingLoop.getInductionVar();
+    Value globalK = rewriter.create<arith::AddIOp>(forOp.getLoc(), kOuter, kInnerPack);
+    
+    // Clone Loads
+    IRMapping mapping;
+    mapping.map(forOp.getInductionVar(), globalK);
+    
+    std::function<Value(Value)> cloneRecursive = [&](Value val) -> Value {
+        if (mapping.contains(val)) return mapping.lookup(val);
+        Operation* defOp = val.getDefiningOp();
+        if (!defOp || defOp->getBlock() != forOp.getBody()) return val;
+        
+        IRMapping localMap;
+        for (Value op : defOp->getOperands()) {
+            localMap.map(op, cloneRecursive(op));
+        }
+        Operation* clonedOp = rewriter.clone(*defOp, localMap);
+        for (unsigned i = 0; i < defOp->getNumResults(); ++i) {
+            mapping.map(defOp->getResult(i), clonedOp->getResult(i));
+        }
+        for (unsigned i = 0; i < defOp->getNumResults(); ++i) {
+            if (defOp->getResult(i) == val) return clonedOp->getResult(i);
+        }
+        return Value();
+    };
+
+    // Clone dependencies for LoadA
+    for (Value op : loadA->getOperands()) {
+        cloneRecursive(op);
+    }
+    Operation* newLoadA = rewriter.clone(*loadA, mapping);
+    
+    // Clone dependencies for LoadB
+    for (Value op : loadB->getOperands()) {
+        cloneRecursive(op);
+    }
+    Operation* newLoadB = rewriter.clone(*loadB, mapping);
+    
+    // Store to Packed
+    storeTensorToMemRef(rewriter, forOp.getLoc(), newLoadA->getResult(0), packedA, kInnerPack, true);
+    storeTensorToMemRef(rewriter, forOp.getLoc(), newLoadB->getResult(0), packedB, kInnerPack, false);
+    
+    rewriter.create<scf::YieldOp>(forOp.getLoc());
+    
+    rewriter.setInsertionPointAfter(packingLoop);
+
+    // Inner Compute Loop
+    auto innerLoop = rewriter.create<scf::ForOp>(
+        forOp.getLoc(), c0, cCacheTileK, cBlockK, outerLoop.getRegionIterArgs());
+    
+    rewriter.setInsertionPointToStart(innerLoop.getBody());
+    Value kInner = innerLoop.getInductionVar();
+    Value accInner = innerLoop.getRegionIterArgs()[0];
+    
+    // Load from Packed
+    Value aFast = loadTensorFromMemRef(rewriter, forOp.getLoc(), packedA, kInner, tensorTypeA, true);
+    Value bFast = loadTensorFromMemRef(rewriter, forOp.getLoc(), packedB, kInner, tensorTypeB, false);
+    
+    // Dot
+    SmallVector<Value> newDotOperands;
+    newDotOperands.push_back(aFast);
+    newDotOperands.push_back(bFast);
+    newDotOperands.push_back(accInner); // C
+    
+    auto newDot = rewriter.create<triton::DotOp>(forOp.getLoc(), dotOp.getType(), newDotOperands, dotOp->getAttrs());
+    
+    rewriter.create<scf::YieldOp>(forOp.getLoc(), newDot.getResult());
+    
+    rewriter.setInsertionPointAfter(innerLoop);
+    rewriter.create<scf::YieldOp>(forOp.getLoc(), innerLoop.getResults());
+    
+    rewriter.replaceOp(forOp, outerLoop.getResults());
+    
+    return success();
+  }
+};
+*/
+class TritonCPUBlockPackingPass : public PassWrapper<TritonCPUBlockPackingPass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TritonCPUBlockPackingPass)
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    MLIRContext *context = &getContext();
+
+    RewritePatternSet patterns(context);
+    patterns.add<BlockPackingPattern>(context);
+
+    if (failed(applyPatternsGreedily(module, std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<Pass> createTritonCPUBlockPackingPass() {
+  return std::make_unique<TritonCPUBlockPackingPass>();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/lib/Dialect/Triton/Transforms/TritonCPUBlockPacking.cpp
+++ b/lib/Dialect/Triton/Transforms/TritonCPUBlockPacking.cpp
@@ -31,43 +31,34 @@ Value memrefToPtr(PatternRewriter &rewriter, Location loc, Value memref) {
     return rewriter.create<triton::IntToPtrOp>(loc, ptrType, basePtrInt);
 }
 
-// Helper to create a tensor of pointers
-Value getPtrTensor(PatternRewriter &rewriter, Location loc, Value basePtr, ArrayRef<int64_t> shape, Value offsetK, int64_t packedWidth, bool isA) {
-    int64_t dim0 = shape[0];
-    int64_t dim1 = shape[1];
+// Optimization: Generate pointers for a contiguous row-major block [Rows, Cols]
+// Offset = Base + (RowIdx * Stride) + ColIdx
+Value createBlockPointers(PatternRewriter &rewriter, Location loc, Value basePtr, ArrayRef<int64_t> shape, int64_t stride) {
+    int64_t rows = shape[0];
+    int64_t cols = shape[1];
     
-    // Create ranges
-    Value range0 = rewriter.create<triton::MakeRangeOp>(loc, RankedTensorType::get({dim0}, rewriter.getI32Type()), 0, dim0);
-    Value range1 = rewriter.create<triton::MakeRangeOp>(loc, RankedTensorType::get({dim1}, rewriter.getI32Type()), 0, dim1);
+    // 1. Create Range(0, Rows) and Range(0, Cols)
+    Value rangeRows = rewriter.create<triton::MakeRangeOp>(loc, RankedTensorType::get({rows}, rewriter.getI32Type()), 0, rows);
+    Value rangeCols = rewriter.create<triton::MakeRangeOp>(loc, RankedTensorType::get({cols}, rewriter.getI32Type()), 0, cols);
     
-    // Broadcast
-    Value range0Bc = rewriter.create<triton::ExpandDimsOp>(loc, range0, 1);
-    range0Bc = rewriter.create<triton::BroadcastOp>(loc, RankedTensorType::get({dim0, dim1}, rewriter.getI32Type()), range0Bc);
+    // 2. Expand and Broadcast to [Rows, Cols]
+    Value rows2D = rewriter.create<triton::ExpandDimsOp>(loc, rangeRows, 1);
+    rows2D = rewriter.create<triton::BroadcastOp>(loc, RankedTensorType::get({rows, cols}, rewriter.getI32Type()), rows2D);
     
-    Value range1Bc = rewriter.create<triton::ExpandDimsOp>(loc, range1, 0);
-    range1Bc = rewriter.create<triton::BroadcastOp>(loc, RankedTensorType::get({dim0, dim1}, rewriter.getI32Type()), range1Bc);
+    Value cols2D = rewriter.create<triton::ExpandDimsOp>(loc, rangeCols, 0);
+    cols2D = rewriter.create<triton::BroadcastOp>(loc, RankedTensorType::get({rows, cols}, rewriter.getI32Type()), cols2D);
     
-    Value cPackedWidth = rewriter.create<arith::ConstantIntOp>(loc, packedWidth, 32);
-    Value splatPackedWidth = rewriter.create<triton::SplatOp>(loc, RankedTensorType::get({dim0, dim1}, rewriter.getI32Type()), cPackedWidth);
+    // 3. Calculate Linear Offsets: (Row * Stride) + Col
+    Value cStride = rewriter.create<arith::ConstantIntOp>(loc, stride, 32);
+    Value strideSplat = rewriter.create<triton::SplatOp>(loc, RankedTensorType::get({rows, cols}, rewriter.getI32Type()), cStride);
     
-    Value offsetK_i32 = rewriter.create<arith::IndexCastOp>(loc, rewriter.getI32Type(), offsetK);
-    Value splatOffsetK = rewriter.create<triton::SplatOp>(loc, RankedTensorType::get({dim0, dim1}, rewriter.getI32Type()), offsetK_i32);
+    Value rowOffset = rewriter.create<arith::MulIOp>(loc, rows2D, strideSplat);
+    Value totalOffset = rewriter.create<arith::AddIOp>(loc, rowOffset, cols2D);
     
-    Value linearOffset;
-    if (isA) {
-        // i * packedWidth + j + offsetK
-        Value term0 = rewriter.create<arith::MulIOp>(loc, range0Bc, splatPackedWidth);
-        Value term1 = rewriter.create<arith::AddIOp>(loc, term0, range1Bc);
-        linearOffset = rewriter.create<arith::AddIOp>(loc, term1, splatOffsetK);
-    } else {
-        // (i + offsetK) * packedWidth + j
-        Value iPlusOffset = rewriter.create<arith::AddIOp>(loc, range0Bc, splatOffsetK);
-        Value term0 = rewriter.create<arith::MulIOp>(loc, iPlusOffset, splatPackedWidth);
-        linearOffset = rewriter.create<arith::AddIOp>(loc, term0, range1Bc);
-    }
+    // 4. Add to Base Pointer
+    Value baseSplat = rewriter.create<triton::SplatOp>(loc, RankedTensorType::get({rows, cols}, basePtr.getType()), basePtr);
     
-    Value splatBase = rewriter.create<triton::SplatOp>(loc, RankedTensorType::get({dim0, dim1}, basePtr.getType()), basePtr);
-    return rewriter.create<triton::AddPtrOp>(loc, splatBase.getType(), splatBase, linearOffset);
+    return rewriter.create<triton::AddPtrOp>(loc, baseSplat.getType(), baseSplat, totalOffset);
 }
 
 // Helper to store a tensor to a memref (pointer)
@@ -80,7 +71,37 @@ void storeTensorToMemRef(PatternRewriter &rewriter, Location loc, Value tensor, 
     int64_t packedWidth = memRefType.getShape()[1];
     
     Value basePtr = memrefToPtr(rewriter, loc, memref);
-    Value ptrs = getPtrTensor(rewriter, loc, basePtr, shape, offsetK, packedWidth, isA);
+    
+    // Calculate Base Offset
+    Value ptrOffset;
+    if (isA) {
+        // For A (MxK), we are storing a block at offsetK in the K dimension (dim 1).
+        // Base Offset = offsetK
+        // offsetK is likely i32 or index, cast to i64 for pointer arithmetic
+        if (offsetK.getType().isIndex()) {
+             ptrOffset = rewriter.create<arith::IndexCastOp>(loc, rewriter.getI64Type(), offsetK);
+        } else {
+             ptrOffset = rewriter.create<arith::ExtSIOp>(loc, rewriter.getI64Type(), offsetK);
+        }
+    } else {
+        // For B (KxN), we are storing a block at offsetK in the K dimension (dim 0).
+        // Base Offset = offsetK * packedWidth (Stride)
+        Value offsetK_i64;
+        if (offsetK.getType().isIndex()) {
+             offsetK_i64 = rewriter.create<arith::IndexCastOp>(loc, rewriter.getI64Type(), offsetK);
+        } else {
+             offsetK_i64 = rewriter.create<arith::ExtSIOp>(loc, rewriter.getI64Type(), offsetK);
+        }
+        Value width_i64 = rewriter.create<arith::ConstantIntOp>(loc, packedWidth, 64);
+        ptrOffset = rewriter.create<arith::MulIOp>(loc, offsetK_i64, width_i64);
+    }
+    
+    // Adjust Base Pointer
+    Type ptrType = basePtr.getType();
+    Value offsetPtr = rewriter.create<triton::AddPtrOp>(loc, ptrType, basePtr, ptrOffset);
+
+    // Generate Pointers
+    Value ptrs = createBlockPointers(rewriter, loc, offsetPtr, shape, packedWidth);
     
     rewriter.create<triton::StoreOp>(loc, ptrs, tensor, triton::CacheModifier::NONE, triton::EvictionPolicy::NORMAL);
 }
@@ -94,7 +115,33 @@ Value loadTensorFromMemRef(PatternRewriter &rewriter, Location loc, Value memref
     int64_t packedWidth = memRefType.getShape()[1];
     
     Value basePtr = memrefToPtr(rewriter, loc, memref);
-    Value ptrs = getPtrTensor(rewriter, loc, basePtr, shape, offsetK, packedWidth, isA);
+    
+    // Calculate Base Offset
+    Value ptrOffset;
+    if (isA) {
+        // offsetK is likely i32 or index, cast to i64 for pointer arithmetic
+        if (offsetK.getType().isIndex()) {
+             ptrOffset = rewriter.create<arith::IndexCastOp>(loc, rewriter.getI64Type(), offsetK);
+        } else {
+             ptrOffset = rewriter.create<arith::ExtSIOp>(loc, rewriter.getI64Type(), offsetK);
+        }
+    } else {
+        Value offsetK_i64;
+        if (offsetK.getType().isIndex()) {
+             offsetK_i64 = rewriter.create<arith::IndexCastOp>(loc, rewriter.getI64Type(), offsetK);
+        } else {
+             offsetK_i64 = rewriter.create<arith::ExtSIOp>(loc, rewriter.getI64Type(), offsetK);
+        }
+        Value width_i64 = rewriter.create<arith::ConstantIntOp>(loc, packedWidth, 64);
+        ptrOffset = rewriter.create<arith::MulIOp>(loc, offsetK_i64, width_i64);
+    }
+    
+    // Adjust Base Pointer
+    Type ptrType = basePtr.getType();
+    Value offsetPtr = rewriter.create<triton::AddPtrOp>(loc, ptrType, basePtr, ptrOffset);
+
+    // Generate Pointers
+    Value ptrs = createBlockPointers(rewriter, loc, offsetPtr, shape, packedWidth);
     
     return rewriter.create<triton::LoadOp>(loc, ptrs, triton::CacheModifier::NONE, triton::EvictionPolicy::NORMAL, false);
 }

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -41,6 +41,7 @@ void init_triton_passes_ttir(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_rewrite_tensor_pointer",
                      createRewriteTensorPointerPass);
   ADD_PASS_WRAPPER_0("add_loop_unroll", createLoopUnrollPass);
+  ADD_PASS_WRAPPER_0("add_triton_cpu_block_packing", createTritonCPUBlockPackingPass);
   ADD_PASS_WRAPPER_0("add_triton_licm", createLoopInvariantCodeMotionPass);
   ADD_PASS_WRAPPER_4("add_convert_to_ttgpuir",
                      createConvertTritonToTritonGPUPass, const std::string &,

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -157,6 +157,7 @@ class CPUBackend(BaseBackend):
         pm.enable_debug()
         passes.common.add_inliner(pm)
         passes.ttir.add_combine(pm)
+        passes.ttir.add_triton_cpu_block_packing(pm)
         passes.common.add_canonicalizer(pm)
         passes.ttir.add_reorder_broadcast(pm)
         passes.common.add_cse(pm)


### PR DESCRIPTION
### PR Title: Implement Block Packing Optimization for Matrix Multiplication

### Description
This PR introduces a new optimization pass `TritonCPUBlockPackingPass` for the Triton CPU backend to improve the performance of matrix multiplication by implementing cache blocking and data packing.

### Key Changes

1.  **New Pass: `TritonCPUBlockPackingPass`**
    *   **Location**: `lib/Dialect/Triton/Transforms/TritonCPUBlockPacking.cpp`
    *   **Functionality**:
        *   Identifies matrix multiplication loops (scf.for containing triton.dot).
        *   Tiles the reduction dimension (K) into smaller blocks (defined by `CACHE_TILE_K = 256`).
        *   Restructures the loop into:
            *   **Outer Loop**: Iterates over the K dimension in tiles.
            *   **Packing Loop**: Copies the current blocks of matrices A and B into contiguous scratchpad memory (`memref.alloca`). This ensures that the data used in the inner loop is contiguous in memory, improving cache locality.
            *   **Inner Compute Loop**: Performs the dot product using the packed data from the scratchpads.
    *   **Registration**: The pass is registered in `Passes.h`, `CMakeLists.txt`, `python/src/passes.cc`, and added to the pipeline in `third_party/cpu/backend/compiler.py`.

2.  **Optimization: Reduce Scalarization Overhead**
    *   Refactored the pointer generation logic within the block packing pass to minimize overhead during lowering.
    *   **Change**: Replaced the initial `getPtrTensor` implementation with `createBlockPointers`.
    *   **Detail**: Instead of calculating the linear offset for every element in the tensor including the loop-dependent `offsetK` (which involves expensive tensor arithmetic), the new approach performs scalar pointer arithmetic to adjust the base pointer by `offsetK` first. It then adds a constant block offset tensor to this adjusted base. This reduces the complexity of address calculations and scalarization overhead.

### Commits
*   `b1eb309` Reduce Scalarization Overhead
*   `adf7839` Implemented blocking pass for optimise matrix mul### PR Title: Implement Block Packing Optimization for Matrix Multiplication